### PR TITLE
Fetch thread names from ruby when outputting

### DIFF
--- a/lib/vernier/output/firefox.rb
+++ b/lib/vernier/output/firefox.rb
@@ -165,6 +165,15 @@ module Vernier
           @tid = tid
           @name = name
 
+          if @name == ""
+            tr = ObjectSpace._id2ref(@ruby_thread_id)
+            if tr && tr.name && !tr.name.empty?
+              @name = tr.name
+            else
+              @name = "UNNAMED [#{@ruby_thread_id}]"
+            end
+          end
+
           timestamps ||= [0] * samples.size
           @samples, @weights, @timestamps = samples, weights, timestamps
           @sample_categories = sample_categories || ([0] * samples.size)


### PR DESCRIPTION
# Problem

It looks like nothing actually sets the thread name, so the tracks in firefox-profiler will not show any name:

<img width="314" alt="Screenshot 2024-02-23 at 1 24 39 PM" src="https://github.com/dalehamel/vernier/assets/618615/6bcfa4d7-68f1-4e34-a890-7cb299107579">

Checking out the json file that is going into this, the thread name is "". If no name was every set, this is expected. However if a name was set, it is still not making it to the gecko output.

I originally suspected https://github.com/jhawthorn/vernier/pull/46, but this is happening for me (on ruby 3.3.0) even with older gems (0.3.0, 0.3.1) that tried to get it from the pthread. In any case, the code to get this from the native extension is [currently commented out](https://github.com/jhawthorn/vernier/blob/v0.4.0/ext/vernier/vernier.cc#L875-L880) and nothing seems to set it anywhere.

# Proposed solution

Since we store the object id for the thread, we can use this to look up the thread and get its name.

If no name was ever set, I think it is still better to give the thread a name in the output so that the dropdown will be more intuitive. With this proposed change, here is what the output looks like:

<img width="227" alt="Screenshot 2024-02-23 at 1 28 22 PM" src="https://github.com/dalehamel/vernier/assets/618615/1cc30af1-8341-4ac1-b314-d0d8608dc24e">

The unnamed threads are distinguished by the thread's object id, which is kind of an arbitrary decision but seems like a reasonable default.